### PR TITLE
feat: reading data from existing readmes

### DIFF
--- a/AssM.csproj
+++ b/AssM.csproj
@@ -5,11 +5,11 @@
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
-        <Version>1.1.1</Version>
+        <Version>1.2.0</Version>
         <Authors>SubZeroPL</Authors>
         <PackageProjectUrl>https://github.com/SubZeroPL/AssM/</PackageProjectUrl>
-        <AssemblyVersion>1.1.1</AssemblyVersion>
-        <FileVersion>1.1.1</FileVersion>
+        <AssemblyVersion>1.2.0</AssemblyVersion>
+        <FileVersion>1.2.0</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Classes/ChdProcessing.cs
+++ b/Classes/ChdProcessing.cs
@@ -1,0 +1,6 @@
+namespace AssM.Classes;
+
+public enum ChdProcessing
+{
+    DontGenerate, GenerateMissing, GenerateAll
+}

--- a/Classes/Configuration.cs
+++ b/Classes/Configuration.cs
@@ -6,7 +6,7 @@ namespace AssM.Classes;
 public class Configuration
 {
     public string OutputDirectory { get; set; } = string.Empty;
-    public bool OverwriteExistingChds { get; set; }
+    public ChdProcessing ChdProcessing { get; set; }
     public bool OverwriteExistingReadmes { get; set; }
     public bool GetTitleFromCue { get; set; }
     public bool GameIdAsChdName { get; set; }

--- a/Data/Game.cs
+++ b/Data/Game.cs
@@ -8,9 +8,9 @@ namespace AssM.Data;
 public class Game
 {
     public string Title { get; set; } = string.Empty;
-    public string Id { get; init; } = string.Empty;
-    public string CuePath { get; init; } = string.Empty;
-    public DetectedDiscType Platform { get; init; }
+    public string Id { get; set; } = string.Empty;
+    public string CuePath { get; set; } = string.Empty;
+    public DetectedDiscType Platform { get; set; } = DetectedDiscType.UnknownFormat;
     public bool ReadmeCreated { get; set; }
     public bool ChdCreated { get; set; }
     public string Description { get; set; } = string.Empty;

--- a/Windows/AddFolderProgressWindow.axaml.cs
+++ b/Windows/AddFolderProgressWindow.axaml.cs
@@ -30,7 +30,7 @@ public partial class AddFolderProgressWindow : Window
         foreach (var cueFile in cueFiles)
         {
             if (_cancelled) return;
-            await Task.Run(() => Functions.AddGameToList(cueFile, configuration.GetTitleFromCue, gameList));
+            await Task.Run(() => Functions.AddGameToList(cueFile, configuration, gameList));
         }
 
         if (string.IsNullOrWhiteSpace(configuration.OutputDirectory)) return;

--- a/Windows/MainWindow.axaml
+++ b/Windows/MainWindow.axaml
@@ -18,10 +18,14 @@
                     </Panel>
                     <Button.Flyout>
                         <MenuFlyout>
-                            <CheckBox Name="CheckBoxOverwriteChd" IsThreeState="False">Overwrite existing CHDs</CheckBox>
-                            <CheckBox Name="CheckBoxOverwriteReadme" IsThreeState="False">Overwrite existing READMEs</CheckBox>
-                            <CheckBox Name="CheckBoxGetTitleFromCue" IsThreeState="False">Get game title from CUE file name</CheckBox>
-                            <CheckBox Name="CheckBoxGameIdAsChdName" IsThreeState="False">Use Game ID as name for CHD file</CheckBox>
+                            <MenuItem Header="CHD operations">
+                                <RadioButton GroupName="Chd" Name="RadioButtonDontGenerate" Tag="DontGenerate" Click="CheckBox_OnClick">Don't generate CHDs</RadioButton>
+                                <RadioButton GroupName="Chd" Name="RadioButtonGenerateMissing" Tag="GenerateMissing" Click="CheckBox_OnClick">Generate only missing</RadioButton>
+                                <RadioButton GroupName="Chd" Name="RadioButtonGenerateAll" Tag="GenerateAll" Click="CheckBox_OnClick">Generate all (overwrite existing)</RadioButton>
+                            </MenuItem>
+                            <CheckBox Name="CheckBoxOverwriteReadme" IsThreeState="False" Click="CheckBox_OnClick">Overwrite existing READMEs</CheckBox>
+                            <CheckBox Name="CheckBoxGetTitleFromCue" IsThreeState="False" Click="CheckBox_OnClick">Get game title from CUE file name</CheckBox>
+                            <CheckBox Name="CheckBoxGameIdAsChdName" IsThreeState="False" Click="CheckBox_OnClick">Use Game ID as name for CHD file</CheckBox>
                         </MenuFlyout>
                     </Button.Flyout>
                 </Button>
@@ -31,7 +35,7 @@
             <Label Target="TextBoxOutputDirectory">Output directory:</Label>
             <DockPanel>
                 <Button DockPanel.Dock="Right" Click="SelectOutputFolderButton_OnClick">Select</Button>
-                <TextBox Name="TextBoxOutputDirectory" Margin="0 0 5 0"></TextBox>
+                <TextBox Name="TextBoxOutputDirectory" TextInput="TextBoxOutputDirectory_OnTextInput" Margin="0 0 5 0"></TextBox>
             </DockPanel>
         </StackPanel>
         <TabControl DockPanel.Dock="Bottom" SelectionChanged="DataGridGameList_OnSelectionChanged">
@@ -86,7 +90,7 @@
                       SelectionChanged="DataGridGameList_OnSelectionChanged">
                 <DataGrid.ContextFlyout>
                     <MenuFlyout>
-                        <MenuItem Name="MenuItemShowReadme" Header="Show README" Click="ShowReadmeMenuItem_OnClick"/>
+                        <MenuItem Name="MenuItemShowReadme" Header="Show README" Click="MenuItemShowReadme_OnClick"/>
                         <MenuItem Name="MenuItemOpenFolder" Header="Open output folder" Click="MenuItemOpenFolder_OnClick"/>
                     </MenuFlyout>
                 </DataGrid.ContextFlyout>

--- a/Windows/ProgressWindow.axaml.cs
+++ b/Windows/ProgressWindow.axaml.cs
@@ -55,9 +55,10 @@ public partial class ProgressWindow : Window
     private async Task ConvertSingleChd(Game game, Action<double> reportProgress)
     {
         if (_cancelled) return;
+        if (_configuration.ChdProcessing == ChdProcessing.DontGenerate) return;
         var chdFile = Functions.GetChdName(game, _configuration);
         var chdPath = Path.Combine(_configuration.OutputDirectory, Functions.OutputPath(game), chdFile);
-        if (File.Exists(chdPath) && !_configuration.OverwriteExistingChds) return;
+        if (File.Exists(chdPath) && _configuration.ChdProcessing != ChdProcessing.GenerateAll) return;
         Directory.CreateDirectory(Path.GetDirectoryName(chdPath) ?? string.Empty);
 
         var chdmanConvert = new Process
@@ -136,6 +137,7 @@ public partial class ProgressWindow : Window
         var readmePath = Path.Combine(_configuration.OutputDirectory, Functions.OutputPath(game), Constants.ReadmeFile);
         if (File.Exists(readmePath) && !_configuration.OverwriteExistingReadmes) return;
         var cuefile = game.CuePath;
+        if (string.IsNullOrWhiteSpace(cuefile)) return;
         var lines = File.ReadLines(cuefile);
         List<string> bins = [];
         bins.AddRange(from line in lines


### PR DESCRIPTION
When output directory already contains some generated data (CHDs or READMEs) then the app will read it and present in the list 
Also it can now generate CHDs only when missing or not at all