### PR TITLE
fix: readme path not exists

### DIFF
--- a/AssM.csproj
+++ b/AssM.csproj
@@ -5,11 +5,11 @@
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
-        <Version>1.2.0</Version>
+        <Version>1.2.1</Version>
         <Authors>SubZeroPL</Authors>
         <PackageProjectUrl>https://github.com/SubZeroPL/AssM/</PackageProjectUrl>
-        <AssemblyVersion>1.2.0</AssemblyVersion>
-        <FileVersion>1.2.0</FileVersion>
+        <AssemblyVersion>1.2.1</AssemblyVersion>
+        <FileVersion>1.2.1</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Windows/ProgressWindow.axaml.cs
+++ b/Windows/ProgressWindow.axaml.cs
@@ -178,6 +178,8 @@ public partial class ProgressWindow : Window
         if (_cancelled) return;
         var readmePath = Path.Combine(_configuration.OutputDirectory, Functions.OutputPath(game), Constants.ReadmeFile);
         if (File.Exists(readmePath) && !_configuration.OverwriteExistingReadmes) return;
+        var dir = Path.GetDirectoryName(readmePath);
+        if (!string.IsNullOrWhiteSpace(dir)) Directory.CreateDirectory(dir);
         var template = File.ReadAllText(Constants.ReadmeTemplate);
         template = template.Replace(Constants.ReadmeGameTitle, game.Title);
         template = template.Replace(Constants.ReadmeGameId, game.Id);


### PR DESCRIPTION
When README was generated first time without generating CHD there was an error because the directory was not created